### PR TITLE
Add Next.js output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.next/


### PR DESCRIPTION
## Summary
- ignore `.next/` folder in Git

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68509f468d6483339b3bb73007676a0a